### PR TITLE
Fix the limit per download to 60

### DIFF
--- a/src/requestHelper.py
+++ b/src/requestHelper.py
@@ -8,7 +8,7 @@ def fetch_data(offset):
     cookies = CONFIG['COOKIES']
     sort_direction = CONFIG['SORT_DIRECTION']
     try:
-        url = f"https://medal.tv/api/content?userId={user_id}&limit=100&offset={offset}&sortBy=publishedAt&sortDirection={sort_direction}"
+        url = f"https://medal.tv/api/content?userId={user_id}&limit=60&offset={offset}&sortBy=publishedAt&sortDirection={sort_direction}"
         response = requests.get(url, cookies=cookies)
         if response.status_code == 200:
              data = response.json()


### PR DESCRIPTION
Medal has decreased their API limit for fetching content from 100 to 60.

This commit changed this, so that the API is now being called with the correct limit of 60 clips per request.